### PR TITLE
Properly check if canvas element is missing

### DIFF
--- a/source/components/Unity.ts
+++ b/source/components/Unity.ts
@@ -84,7 +84,7 @@ export default class Unity extends React.Component<IUnityProps, IUnityState> {
     const _width = this.htmlElement!.offsetWidth;
     const _height = this.htmlElement!.offsetHeight;
     const _canvas = this.htmlElement!.getElementsByTagName("canvas")[0];
-    if (_canvas !== null) {
+    if (_canvas != null) {
       if (_canvas.height !== _height) {
         _canvas.height = _height;
       }


### PR DESCRIPTION
If you call this before the component has mounted the canvas, `_canvas` will be `undefined`, not `null`.