### PR TITLE
add tabindex prop to enable keyboard interaction with inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,53 @@
 {
   "name": "react-unity-webgl",
   "version": "8.0.3",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "8.0.3",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/react": "17.0.1",
+        "typescript": "4.1.3"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/prop-types": {
       "version": "15.7.3",
@@ -11,9 +56,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
-      "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -27,9 +72,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     }
   }

--- a/source/components/unity.ts
+++ b/source/components/unity.ts
@@ -91,6 +91,7 @@ export default class Unity extends PureComponent<IUnityProps, {}> {
   public render(): React.ReactNode {
     return createElement("canvas", {
       className: this.props.className || "",
+      tabIndex: this.props.tabIndex,
       ref: (r: HTMLCanvasElement) => (this.htmlCanvasElementReference = r),
       style: {
         width: this.props.width || "800px",

--- a/source/interfaces/unityProps.ts
+++ b/source/interfaces/unityProps.ts
@@ -24,4 +24,13 @@ export default interface IUnityProps {
    * @type {string | number}
    */
   height?: string | number;
+
+  /**
+   * The tabIndex of the element.
+   * Mitigates the issue that once WebGL is loaded, the keyboard is captured
+   * and HTML inputs are not reacting to keyboard strokes anymore.
+   * @type {number}
+   * @see https://stackoverflow.com/a/60854680
+   */
+  tabIndex?: number;
 }


### PR DESCRIPTION
When implementing this for a project, I noticed the strange behavior that every input on the site stopped working as soon as I loaded up a Unity WebGL component.

Apparently, this has to do with the WebGL keyboard capturing that is turned on by default when building with Unity.
It was found out that giving the `<canvas>` element a positive `tabindex` attribute along with the `WebGLInput.captureAllKeyboardInput = false;` inside the Unity project mitigates this issue, as described here:

 https://stackoverflow.com/a/6085468

This pull request implements the optional `tabIndex` prop on the `<Unity>` component. There are no breaking changes when not using this prop, as it is fully optional.

Please consider merging and releasing this feature as soon as possible, as it mitigates a very serious issue i face with my project.
Thanks for your work on this project!