### PR TITLE
gatsby build bug fixes

### DIFF
--- a/source/models/unity-context.ts
+++ b/source/models/unity-context.ts
@@ -31,7 +31,7 @@ export default class UnityContext {
    * @param {IUnityConfig} unityConfig The Unity config used to build the player.
    */
   constructor(public unityConfig: IUnityConfig) {
-    if (typeof (window as any).ReactUnityWebGL === "undefined")
+    if (typeof window !== "undefined" && typeof (window as any).ReactUnityWebGL === "undefined")
       (window as any).ReactUnityWebGL = {};
   }
 
@@ -97,8 +97,9 @@ export default class UnityContext {
     ) => void
   ): void {
     this.unityEvents.push({ eventName, eventCallback: eventListener });
-    (window as any).ReactUnityWebGL[eventName] = (...parameters: any) =>
-      eventListener(...parameters);
+    if (typeof window !== "undefined")
+      (window as any).ReactUnityWebGL[eventName] = (...parameters: any) =>
+        eventListener(...parameters);
   }
 
   /**

--- a/source/models/unity-context.ts
+++ b/source/models/unity-context.ts
@@ -31,7 +31,10 @@ export default class UnityContext {
    * @param {IUnityConfig} unityConfig The Unity config used to build the player.
    */
   constructor(public unityConfig: IUnityConfig) {
-    if (typeof window !== "undefined" && typeof (window as any).ReactUnityWebGL === "undefined")
+    if (
+      typeof window !== "undefined" &&
+      typeof (window as any).ReactUnityWebGL === "undefined"
+    )
       (window as any).ReactUnityWebGL = {};
   }
 

--- a/source/services/unity-loader-service.ts
+++ b/source/services/unity-loader-service.ts
@@ -12,7 +12,10 @@ export default class UnityLoaderService {
    * A reference to the document head.
    * @type {HTMLHeadElement}
    */
-  private documentHead: HTMLHeadElement = document.querySelector("head")!;
+  private documentHead: HTMLHeadElement | undefined =
+    typeof document !== "undefined"
+      ? document.querySelector("head")!
+      : undefined;
 
   /**
    * Adds the Unity loader script to the window. When a version of the loader
@@ -45,13 +48,16 @@ export default class UnityLoaderService {
    */
   private appendAndLoadScript(url: string): Promise<HTMLScriptElement> {
     return new Promise<HTMLScriptElement>((resolve, reject) => {
-      var _scriptTag = document.createElement("script");
-      _scriptTag.type = "text/javascript";
-      _scriptTag.async = true;
-      _scriptTag.src = url;
-      _scriptTag.onload = () => resolve(_scriptTag!);
-      _scriptTag.onerror = (error) => reject(`Unable to load ${url} ${error}`);
-      this.documentHead.appendChild(_scriptTag);
+      if (typeof this.documentHead !== "undefined") {
+        var _scriptTag = document.createElement("script");
+        _scriptTag.type = "text/javascript";
+        _scriptTag.async = true;
+        _scriptTag.src = url;
+        _scriptTag.onload = () => resolve(_scriptTag!);
+        _scriptTag.onerror = (error) =>
+          reject(`Unable to load ${url} ${error}`);
+        this.documentHead.appendChild(_scriptTag);
+      }
     });
   }
 }


### PR DESCRIPTION
With Gatsby, `window` is not available when running `gatsby build`. This just adds an extra check before accessing `window` to make sure it is defined.

Current error from `gatsby build`:
![image](https://user-images.githubusercontent.com/28768645/111054024-ecff3b80-841d-11eb-8d70-63ff2b819e8d.png)

More details on the issue, from Gatsby: https://www.gatsbyjs.com/docs/debugging-html-builds/